### PR TITLE
Handle `onPictureInPictureModeChanged` event dispatching on base java module

### DIFF
--- a/android/src/main/java/com/takeoffmediareactnativebitmovinplayer/ReactNativeBitmovinPlayerPackage.kt
+++ b/android/src/main/java/com/takeoffmediareactnativebitmovinplayer/ReactNativeBitmovinPlayerPackage.kt
@@ -1,5 +1,7 @@
 package com.takeoffmediareactnativebitmovinplayer
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
@@ -11,6 +13,7 @@ class ReactNativeBitmovinPlayerPackage : ReactPackage {
     return listOf(ReactNativeBitmovinPlayerModule(reactContext))
   }
 
+  @RequiresApi(Build.VERSION_CODES.O)
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>>{
     return listOf(ReactNativeBitmovinPlayerManager())
   }

--- a/example/android/app/src/main/java/com/example/takeoffmediareactnativebitmovinplayer/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/takeoffmediareactnativebitmovinplayer/MainActivity.java
@@ -1,18 +1,6 @@
 package com.example.takeoffmediareactnativebitmovinplayer;
 
-import android.app.Activity;
-import android.content.res.Configuration;
-
-import androidx.annotation.Nullable;
-
 import com.facebook.react.ReactActivity;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactNativeHost;
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 public class MainActivity extends ReactActivity {
 
@@ -24,31 +12,4 @@ public class MainActivity extends ReactActivity {
   protected String getMainComponentName() {
     return "ReactNativeBitmovinPlayerExample";
   }
-
-  private void sendEvent(ReactContext reactContext,
-                         String eventName,
-                         @Nullable WritableMap params) {
-    reactContext
-      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-      .emit(eventName, params);
-  }
-
-  @Override
-  public void onPictureInPictureModeChanged ( boolean isInPictureInPictureMode, Configuration newConfig) {
-    Activity activity = MainActivity.this;
-    MainApplication application = (MainApplication) activity.getApplication();
-    ReactNativeHost reactNativeHost = application.getReactNativeHost();
-    ReactInstanceManager reactInstanceManager = reactNativeHost.getReactInstanceManager();
-    ReactApplicationContext reactContext = (ReactApplicationContext) reactInstanceManager.getCurrentReactContext();
-    WritableMap params = Arguments.createMap();
-
-    if (isInPictureInPictureMode) {
-      params.putString("PiP_event", "EnterPiP");
-      sendEvent(reactContext, "onPictureInPictureModeChanged",params);
-    } else {
-      params.putString("PiP_event", "ExitPiP");
-      sendEvent(reactContext, "onPictureInPictureModeChanged",params);
-    }
-  }
-
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,6 +114,13 @@ export default React.forwardRef<
     const playerRef = useRef();
 
     useEffect(() => {
+      if (Platform.OS === 'android') {
+        // Make native module listen for lifecycle events on the main activity.
+        ReactNativeBitmovinPlayerModule.registerLifecycleEventObserver();
+      }
+    }, []);
+
+    useEffect(() => {
       const { height } = layout || {};
 
       if (maxHeight !== null && height && !loading) {


### PR DESCRIPTION
Moves `onPictureInPictureModeChanged` event dispatching logic from `MainActivity` to `ReactNativeBitmovinPlayerModule`.
This PR was written for [an answer on stack overflow](https://stackoverflow.com/a/70174114/9494107).